### PR TITLE
Suppress warning

### DIFF
--- a/lib/perfect_retry/config.rb
+++ b/lib/perfect_retry/config.rb
@@ -17,7 +17,7 @@ class PerfectRetry
       end
 
       case log_level
-      when Fixnum
+      when Integer
         logger.level = log_level
         return
       when String, Symbol


### PR DESCRIPTION
This commit will suppress:

```
warning: constant ::Fixnum is deprecated
```